### PR TITLE
CLAB-512 Update path to chromium instead of chromium-browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = async function (config) {
     }
   };
 
-  let executablePath = "/usr/bin/chromium-browser" // for linux machines
+  let executablePath = "/usr/bin/chromium" // for linux machines
   if (process.platform === "darwin") {
     executablePath = "/usr/local/bin/chromium" // for macOS machines
   } else if(process.platform === "win32") {


### PR DESCRIPTION
`chromium-browser` is for Ubuntu-based image which doesn't work so we're using `apt-get install -y chromium` instead for Debian-based image.